### PR TITLE
feat:使用新的UniApp类型命名

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -5,7 +5,7 @@ declare namespace UniCrazyGlobalTypes {
     }
 }
 
-declare namespace UniApp {
+declare namespace UniNamespace {
     interface RedirectToOptions extends UniCrazyGlobalTypes.UniCrazyRouterParams {}
     interface ReLaunchOptions extends UniCrazyGlobalTypes.UniCrazyRouterParams {}
     interface SwitchTabOptions extends UniCrazyGlobalTypes.UniCrazyRouterParams {}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/52436248/199433866-b8114b41-5d69-4762-a4ac-f82e59916f29.png)
![image](https://user-images.githubusercontent.com/52436248/199433987-63516c1c-c1be-4f93-b318-3f69b5441edd.png)
在最新的uniapp类型文件中，命名空间名字变了，导致类型无法正确提示